### PR TITLE
Unobtrusive improvements: won't change the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 template filter, packaged as a standalone Python library and command-line
 application.
 
-
 ## Installation
 
     % [sudo] pip install slugify # OR
@@ -13,18 +12,56 @@ application.
 
 ## Usage
 
-### Python
+Works out of the box for Latin-based scripts:
 
-    >>> import slugify
-    >>> slugify.slugify(u"Héllø Wörld")
-    u"hello-world"
+    >>> from slugify import slugify
+    >>> slugify(u"C'est Noël !")
+    u'cest-noel'
+    >>> slugify(u"C'est Noël !", separator="_")
+    u'cest_noel'
 
+It will handle all unicode equivalences if (and only if) the optional
+unidecode library is installed:
+
+    % [sudo] pip install unidecode # OR
+    % [sudo] easy_install unidecode
+
+Then:
+
+    >>> slugify(u"北亰")
+    u'bei-jing'
+
+More about it:
+  - http://en.wikipedia.org/wiki/Unicode_equivalence;
+  - http://pypi.python.org/pypi/Unidecode.
+
+If you do have unidecode installed, but wish not to use it, use the
+unicodedata_slugify fonction:
+
+    >>> slugify(u"Héllø Wörld") # slugify() uses unidecode if it can
+    u'hello-world'
+    >>> unicodedata_slugify(u"Héllø Wörld") # this will more limited
+    u'hell-world'
+
+If you don't use unidecode, the result may vary according to your Python
+implementation or system. unidecode brings a richer equivalence and
+a more consistent cross plateform output:
+
+    >>> unicodedata_slugify(u"Héllø Wörld") # on Ubuntu 12.04 and Python 2.7
+    u'hell-world'
+    >>> unidecode_slugify(u"Héllø Wörld")
+    u'hello-world'
+
+If ne case you wish to keep the non ASCII caracters "as-is", use
+unicode_slugify():
+
+    >>> print unicode_slugify(u"C'est Noël !")
+    cest-noël
 
 ### Command-line
 
     % echo "Héllø Wörld" | slugify
     hello-world
-
 
 ## License
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import os
 import re
 
-from distutils.core import setup
+from setuptools import setup
 
 
 rel_file = lambda *args: os.path.join(os.path.dirname(os.path.abspath(__file__)), *args)
@@ -31,4 +31,7 @@ setup(
     py_modules       = ['slugify'],
     package_dir      = {'': 'src'},
     scripts          = ['bin/slugify'],
+    extras_require =   {
+        'UnicodeEquivalence':  ["Unidecode>=0.04.9"],
+    }
 )

--- a/src/slugify.py
+++ b/src/slugify.py
@@ -1,29 +1,120 @@
 # -*- coding: utf-8 -*-
+#!/usr/bin/env python
+# vim: ai ts=4 sts=4 et sw=4 nu
 
-"""A generic slugifier utility (currently only for Latin-based scripts)."""
+u"""
+    A generic slugifier utility.
+
+    Works out of the box for Latin-based scripts.
+
+    Example:
+
+        >>> from slugify import slugify
+        >>> slugify(u"C'est Noël !")
+        u'cest-noel'
+        >>> slugify(u"C'est Noël !", separator="_")
+        u'cest_noel'
+
+    It will handle all unicode equivalences if (and only if) the optional
+    unidecode library is installed.
+
+    Example:
+
+        >>> slugify(u"北亰")
+        u'bei-jing'
+
+    More about it:
+      - http://en.wikipedia.org/wiki/Unicode_equivalence;
+      - http://pypi.python.org/pypi/Unidecode.
+
+    If you do have unidecode installed, but wish not to use it, use the
+    unicodedata_slugify fonction:
+
+        >>> slugify(u"Héllø Wörld") # slugify() uses unidecode if it can
+        u'hello-world'
+        >>> unicodedata_slugify(u"Héllø Wörld") # this will more limited
+        u'hell-world'
+
+    If ne case you wish to keep the non ASCII characters "as-is", use
+    unicode_slugify():
+
+    >>> print unicode_slugify(u"C'est Noël !")
+    cest-noël
+
+"""
 
 import re
 import unicodedata
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 
-def slugify(string):
-
-    """
-    Slugify a unicode string.
+def unicode_slugify(string, separator=r'-'):
+    ur"""
+    Slugify a unicode string using to normalize the string, but without trying
+    to convert or strip non ASCII characters.
 
     Example:
 
-        >>> slugify(u"Héllø Wörld")
-        u"hello-world"
-
+        >>> print unicode_slugify(u"Héllø Wörld")
+        héllø-wörld
+        >>> unidecode_slugify(u"Bonjour, tout l'monde !", separator="_")
+        u'bonjour_tout_lmonde'
+        >>> unidecode_slugify(u"\tStuff with -- dashes and...   spaces   \n")
+        u'stuff-with-dashes-and-spaces'
     """
 
-    return re.sub(r'[-\s]+', '-',
-            unicode(
-                re.sub(r'[^\w\s-]', '',
-                    unicodedata.normalize('NFKD', string)
-                    .encode('ascii', 'ignore'))
-                .strip()
-                .lower()))
+    string = re.sub(r'[^\w\s' + separator + ']', '', string, flags=re.U)
+    string = string.strip().lower()
+    return unicode(re.sub(r'[' + separator + '\s]+',
+                   separator, string, flags=re.U))
+
+
+def unicodedata_slugify(string, separator=r'-'):
+    ur"""
+    Slugify a unicode string using unicodedata to normalize the string.
+
+    Example:
+
+        >>> unicodedata_slugify(u"Héllø Wörld")
+        u'hell-world'
+        >>> unidecode_slugify(u"Bonjour, tout l'monde !", separator="_")
+        u'bonjour_tout_lmonde'
+        >>> unidecode_slugify(u"\tStuff with -- dashes and...   spaces   \n")
+        u'stuff-with-dashes-and-spaces'
+    """
+
+    string = unicodedata.normalize('NFKD', string).encode('ascii', 'ignore')
+    string = re.sub(r'[^\w\s' + separator + ']', '', string).strip().lower()
+    return unicode(re.sub(r'[' + separator + '\s]+', separator, string))
+
+
+def unidecode_slugify(string, separator=r'-'):
+    ur"""
+    Slugify a unicode string using unidecode to normalize the string.
+
+    Example:
+
+        >>> unidecode_slugify(u"Héllø Wörld")
+        u'hello-world'
+        >>> unidecode_slugify(u"Bonjour, tout l'monde !", separator="_")
+        u'bonjour_tout_lmonde'
+        >>> unidecode_slugify(u"\tStuff with -- dashes and...   spaces   \n")
+        u'stuff-with-dashes-and-spaces'
+    """
+
+    string = unidecode.unidecode(string)
+    string = re.sub(r'[^\w\s' + separator + ']', '', string).strip().lower()
+    return unicode(re.sub(r'[' + separator + '\s]+', separator, string))
+
+
+try:
+    import unidecode
+    slugify = unidecode_slugify
+except ImportError:
+    slugify = unicodedata_slugify
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/src/slugify.py
+++ b/src/slugify.py
@@ -35,7 +35,7 @@ u"""
         >>> unicodedata_slugify(u"Héllø Wörld") # this will more limited
         u'hell-world'
 
-    If ne case you wish to keep the non ASCII characters "as-is", use
+    In case you wish to keep the non ASCII characters "as-is", use
     unicode_slugify():
 
     >>> print unicode_slugify(u"C'est Noël !")


### PR DESCRIPTION
I ran:

```
   >>> unidecode_slugify(u"Héllø Wörld")
```

In a shell and didn't get:

```
   u'hello-world'
```

But:

```
   u'hell-world'
```

So I took the chance to make small improvements to this lib. It's 100% compatible with the previous version.

Slugify() now uses the unidecode library if (and only if) installed. 

Unidecode is listed as an optional dependancy in setup.py (I had to switch to setuptools for this, but you can remove this specific change without impacting the benefit of the other changes).

There are 3 subfonctions one can use separatly if one wishes to use either unidecode, unicodedata or just keep non ASCII characters, but most people will just do:

```
>>> from slugify import slugify
```

as usuall (slugify() is now an alias to the best function available).

 You can pass a different separator than "-" although it is the default value. Some people like their slugs with '_', and this lib can be useful to normalize strings for another purpose than for the Web (E.G: filename for scripting).

 The code is backed up with doctests to ensure I didn't destroy your work and help with further improvements. But they won't pass unless you have unidecode installed because I have no clue how to do conditional testing according to available libraries in doctests :-)

I did update the README but I advice proof reading as I'm not a native english speaker.

Cheers !
