### PR TITLE
Make module straddling code.

### DIFF
--- a/bin/slugify
+++ b/bin/slugify
@@ -1,16 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 USAGE = """Usage: echo "Héllo Wörld" | slugify # => hello-world"""
 
 import sys
 import slugify
 
+if sys.version_info[0] == 3:
+    import io
+    input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+else:
+    import codecs
+    in_enc = sys.stdin.encoding
+    in_enc = in_enc if in_enc is not None else 'utf-8'
+    input_stream = codecs.getreader(in_enc)(sys.stdin)
+
 if sys.argv[1:]:
-    print >>sys.stderr, USAGE
+    print(USAGE, file=sys.stderr)
     sys.exit(1)
 
-line = sys.stdin.readline()
+line = input_stream.readline()
 while line:
-    print slugify.slugify(line.decode(sys.stdin.encoding))
-    line = sys.stdin.readline()
+    print(slugify.slugify(line))
+    line = input_stream.readline()

--- a/src/slugify.py
+++ b/src/slugify.py
@@ -3,10 +3,16 @@
 """A generic slugifier utility (currently only for Latin-based scripts)."""
 
 import re
+import sys
 import unicodedata
 
 __version__ = '0.0.1'
 
+# Micro stealing from the six module
+if sys.version_info[0] == 3:
+    text_type = str
+else:
+    text_type = unicode
 
 def slugify(string):
 
@@ -20,10 +26,8 @@ def slugify(string):
 
     """
 
-    return re.sub(r'[-\s]+', '-',
-            unicode(
-                re.sub(r'[^\w\s-]', '',
-                    unicodedata.normalize('NFKD', string)
-                    .encode('ascii', 'ignore'))
-                .strip()
-                .lower()))
+    value = text_type(string)
+    value = unicodedata.normalize('NFKD', value).encode(
+        'ascii', 'ignore').decode('ascii')
+    value = re.sub(r'[^\w\s-]', '', value).strip().lower()
+    return re.sub(r'[-\s]+', '-', value)


### PR DESCRIPTION
``text_type`` (which is both constant and function) cribbed from the ``six`` module.

The rest of the module stolen (again) from Django.

Also fix the slugify script to work in both modes.

Fixes #5